### PR TITLE
Fix power of operator

### DIFF
--- a/DotNetStandardCalculator/ShuntingYard.cs
+++ b/DotNetStandardCalculator/ShuntingYard.cs
@@ -9,7 +9,7 @@ namespace DotNetStandardCalculator
         
         private static Regex isOpenParentheseseRegex = new Regex("\\(");
         private static Regex isCloseParentheseseRegex = new Regex("\\)");
-        private static Regex isOperatorRegex = new Regex("[*/%+\\-]");
+        private static Regex isOperatorRegex = new Regex("[\\^*/%+\\-]");
 
         public static string[] GetRPNAsArrayFromString(string infixNotation)
         {
@@ -71,10 +71,12 @@ namespace DotNetStandardCalculator
             return valuesStack.Reverse().ToArray();
         }
 
-        private static int OperatorPrecedence(char op)
+        private static int OperatorPrecedence(char @operator)
         {
-            switch (op)
+            switch (@operator)
             {
+                case '^':
+                    return 6;
                 case '*':
                 case '/':
                 case '%':

--- a/DotNetStandardCalculator/Utilities.cs
+++ b/DotNetStandardCalculator/Utilities.cs
@@ -8,11 +8,11 @@ namespace DotNetStandardCalculator
     {
         private static Regex isNumberRegex = new Regex("^([0-9]+)?([.][0-9]+)?$");
 
-        private static string[] operatorsInOrder = new[] { "^", "*", "/", "+", "-", "(", ")" };
+        private static string[] operators = new[] { "^", "*", "/", "+", "-", "(", ")" };
 
         public static string[] Split(string stringToSplit)
         {
-            var operatorsRegex = string.Join("|", operatorsInOrder.Select(d => Regex.Escape(d)).ToArray());
+            var operatorsRegex = string.Join("|", operators.Select(d => Regex.Escape(d)).ToArray());
 
             var pattern = $"({operatorsRegex})";
             var split = Regex.Split(stringToSplit, pattern);

--- a/DotNetStandardCalculatorTests/ShuntingYardTests.cs
+++ b/DotNetStandardCalculatorTests/ShuntingYardTests.cs
@@ -60,6 +60,14 @@ namespace DotNetStandardCalculatorTests
             AssertInfixConvertsToExpected(infix, expected);
         }
 
+        [Theory]
+        [InlineData("2 ^ 3", new[] { "2", "3", "^"})]
+        [InlineData("6^2 + 5 * (5+4)", new[] { "6", "2", "^", "5", "5", "4", "+", "*", "+" })]
+        public void PowerOfOperatorShunting(string infix, string[] expected)
+        {
+            AssertInfixConvertsToExpected(infix, expected);
+        }
+
         private void AssertInfixConvertsToExpected(string infix, string[] expected)
         {
             var split = Utilities.Split(infix);

--- a/DotNetStandardCalculatorTests/StandardCalculatorTests.cs
+++ b/DotNetStandardCalculatorTests/StandardCalculatorTests.cs
@@ -33,5 +33,14 @@ namespace DotNetStandardCalculatorTests
         {
             TestCommon.AssertCalculateEqualsValue(infixSum, expected);
         }
+
+        [Theory]
+        [InlineData("4^3 * (60 - 3)", 3648)]
+        [InlineData("4^2 * (6^2 - 3)", 528)]
+        [InlineData("2^2 + 3", 7)]
+        public void PowerOfOperatorWorks(string infixSum, double expected)
+        {
+            TestCommon.AssertCalculateEqualsValue(infixSum, expected);
+        }
     }
 }

--- a/DotNetStandardCalculatorTests/UtilitiesTests.cs
+++ b/DotNetStandardCalculatorTests/UtilitiesTests.cs
@@ -11,6 +11,7 @@ namespace DotNetStandardCalculatorTests
         [InlineData("10+(6/3+3)", new[] { "10", "+", "(", "6", "/", "3", "+", "3", ")" })]
         [InlineData("(10 + 50) * (60 - 10)", new[] { "(", "10", "+", "50", ")", "*", "(", "60", "-", "10", ")" })]
         [InlineData("9 + (3 * 55) / 6", new[] { "9", "+", "(", "3", "*", "55", ")", "/", "6" })]
+        [InlineData("9^3 + (3 * 55) / 6", new[] { "9", "^", "3", "+", "(", "3", "*", "55", ")", "/", "6" })]
         public void SplitTests(string input, string[] expected)
         {
             var splitString = Utilities.Split(input);


### PR DESCRIPTION
### Issue fixed
Fixes #7

### Description
Power of operators now work

### Usage (if applicable)
`var result = "5^2";` 
`result` = 25